### PR TITLE
Made location consistent

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -161,7 +161,7 @@ Use `New-AzSubscriptionDeploymentStack` to create a deploymentStack.
 ```PowerShell
 New-AzSubscriptionDeploymentStack `
   -Name mySubStack `
-  -Location eastus2 `
+  -Location eastus `
   -TemplateFile azuredeploy.json `
   -TemplateParameterFile azuredeploy.parameters.json
 ```


### PR DESCRIPTION
Set the location for the creation of the deploymentStack `eastus` rather than `eastus2`, because the subsequent examples use `eastus` and will cause an error if the stack was created in another location.