### PR TITLE
Fix broken callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # What are deployment stacks?
 
-> [!IMPORTANT]
-> Deployment stacks is currently in private preview. Thus, please treat this
+> IMPORTANT
+> Deployment stacks is currently in _private preview_. Thus, please treat this
 > information as confidential and don't share publicly.
 > Also, private preview features aren't covered by Azure Customer Services & Support (CSS)
 > Instead, please file an [issue](https://github.com/Azure/deployment-stacks/issues) so

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 > [!IMPORTANT]
 > Deployment stacks is currently in private preview. Thus, please treat this
-> information as confidential and do not share publicly.
->
+> information as confidential and don't share publicly.
 > Also, private preview features aren't covered by Azure Customer Services & Support (CSS)
 > Instead, please file an [issue](https://github.com/Azure/deployment-stacks/issues) so
 > we can address your question or concern. Thanks!


### PR DESCRIPTION
I may need to move the `Important` callout a couple paragraphs down the page. I suspect the callout didn't render properly because it was at the top of page. We'll see what the preview shows!