### PR TITLE
Add deterministic issue-triage assistant for the ARM Deployments team

### DIFF
--- a/.github/agents/issue-triage-teammate.md
+++ b/.github/agents/issue-triage-teammate.md
@@ -1,0 +1,89 @@
+# Issue triage teammate (heuristic, no-AI)
+
+A deterministic, rule-based triage assistant for the Azure Deployment Stacks repo.
+
+## Purpose
+
+This agent **does not attempt to fix issues**. It surfaces signal to help a human reviewer prioritize and route. Every classification is traceable to a specific rule.
+
+## Inputs
+
+- Issue title + body
+- All issue comments (read once at triage time)
+
+## Outputs
+
+A single comment on the issue (idempotent — skipped if `<!-- agentry:triage -->` is already present), plus labels. **No PRs. No external API calls.**
+
+### Comment structure
+
+1. **Recommended next step** — one enum value, prominently displayed.
+2. **Category** + severity + confidence.
+3. **Summary** — one-line problem statement.
+4. **Suggested action for reviewer** — concrete next step in plain English.
+5. **Detected topics** — bulleted list (denySettings, action-on-unmanage, etc.).
+6. **Rules fired** — collapsible details block showing exactly which classifier rules matched.
+7. **Heuristic disclaimer footer** — "deterministic classifier, not AI."
+
+### Labels
+
+- `agent:triaged` (always — used for idempotency).
+- `category:<bug|feature-request|question|documentation|security|performance|enhancement>`
+- `severity:<critical|high|medium|low|info>`
+- `next-step:<close-as-by-design|close-as-duplicate|close-as-fixed|run-azure-repro|needs-product-decision|needs-docs-update|needs-more-info|escalate-security|keep-open-tracking>`
+- One `topic:<slug>` label per detected topic.
+
+## Classification rules (first match wins)
+
+### Category
+
+1. **security** — keywords: vulnerability, CVE, credential leak, secret exposure.
+2. **documentation** — title/body explicitly asks about docs being wrong/missing/unclear.
+3. **feature-request** — body uses `**Is your feature request related to a problem?**` (or H1 variant) or `**Describe the solution you'd like**`, or title starts with `feature:`.
+4. **bug** — body uses `**Describe the bug**`, `**Repro Environment**`, or contains a Python traceback.
+5. **performance** — keywords: slow, timeout, takes too long, performance issue, reduce the time.
+6. **question** — title ends with `?`.
+7. **enhancement** — improvement language ("would be great", "could improve", "please add").
+8. **question** — default fallback.
+
+### Severity
+
+- **critical** — data loss / production outage / destroyed.
+- **high** — blocked / cannot deploy / regression / broken in prod.
+- **medium** — bugs / performance issues (default).
+- **medium** — bug with stated workaround.
+- **info** — questions, feature requests (default).
+
+### Topics (multiple may apply)
+
+`denySettings`, `action-on-unmanage`, `delete-failure`, `role-assignment`, `managed-identity`, `bicep-language`, `az-cli`, `powershell-az`, `private-dns-zone`, `by-design`, `known-limitation`, `pipeline`, `error-message-quality`, `portal`.
+
+### Recommended next step
+
+Priority order:
+
+1. `escalate-security` — if category is `security`.
+2. `close-as-fixed` — reporter resolution signals ("that fixes the error", "fix was", "you can close").
+3. `close-as-by-design` — `by-design` or `known-limitation` topic detected.
+4. `needs-docs-update` — category is `documentation`.
+5. `keep-open-tracking` — category is `feature-request` or `enhancement`.
+6. For `question`:
+   - `needs-product-decision` — if a team member (MEMBER/OWNER/COLLABORATOR) has replied.
+   - `needs-more-info` — otherwise.
+7. For `bug`:
+   - `needs-more-info` — if missing both correlation ID and version.
+   - `run-azure-repro` — otherwise.
+8. `keep-open-tracking` — final fallback.
+
+## Confidence
+
+- **high** — classifier used an issue-template heading AND detected ≥2 topics.
+- **medium** — used a template heading OR detected ≥1 topic.
+- **low** — neither.
+
+## Non-goals
+
+- **No code fixes.** This agent will never open a PR.
+- **No external API calls** beyond GitHub. No Azure OpenAI, no Azure ARM operations, no third-party services.
+- **No autonomous closure.** Closing an issue is a human decision; the agent only recommends.
+- **No comment cleanup.** The agent posts at most one comment per issue (idempotent via the `<!-- agentry:triage -->` marker).

--- a/.github/workflows/agent-triage-batch.yml
+++ b/.github/workflows/agent-triage-batch.yml
@@ -1,0 +1,54 @@
+name: Agent — nightly batch triage
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+  # First-time deployment kick: when this workflow file or the bot source
+  # changes on `main`, run the batch once so newly-deployed installs (or
+  # bot updates) backfill across all open issues without a manual nudge.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/agent-triage-batch.yml'
+      - 'src/**'
+      - 'scripts/triage-single-issue.js'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  batch-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Find untriaged open issues
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
+            --json number,labels \
+            --jq '[.[] | select((.labels | map(.name)) | index("agent:triaged") | not) | .number] | join(",")' \
+            > issues.csv
+          NUMS="$(cat issues.csv)"
+          echo "Found untriaged issues: ${NUMS:-(none)}"
+          echo "issues=$NUMS" >> "$GITHUB_OUTPUT"
+
+      - name: Triage each issue
+        if: steps.find.outputs.issues != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          IFS=',' read -ra NUMS <<< "${{ steps.find.outputs.issues }}"
+          for n in "${NUMS[@]}"; do
+            echo "::group::Triaging #$n"
+            ISSUE_NUMBER="$n" node scripts/triage-single-issue.js || echo "Triage failed for #$n (continuing batch)"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/agent-triage.yml
+++ b/.github/workflows/agent-triage.yml
@@ -1,0 +1,30 @@
+name: Agent — triage on issue open
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Triage single issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
+        run: node scripts/triage-single-issue.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# Agent — automated issue triage assistant
+
+This repo runs an **automated issue triage assistant** for the ARM Deployments
+team. When you open a new issue, the bot posts a single comment within ~1
+minute that does three things:
+
+1. **Categorizes** the issue (bug / feature-request / question / docs / etc.)
+   and applies labels so the team can scan a board view.
+2. **Suggests docs** that might help you while you wait, based on phrases and
+   topics it detects in the title/body.
+3. **Flags possible duplicates** if it sees other open issues that look related.
+
+This is **not AI** — it's a small deterministic rule-based classifier. There
+is no LLM, no model, no API key. It uses regex and string matching only. The
+source lives in [`src/`](src/) (~30 KB of Node 20 JavaScript, zero runtime
+dependencies). A human team member still reviews every issue — the bot is
+there to surface signal, not to take autonomous action.
+
+## How the bot decides what to do
+
+| Step                  | File                                | What it does                                                |
+| --------------------- | ----------------------------------- | ----------------------------------------------------------- |
+| Classification        | [`src/heuristic-triage.js`](src/heuristic-triage.js) | Category, severity, topics, recommended next step, confidence, age signals |
+| Doc selection         | [`src/docs-pointers.js`](src/docs-pointers.js)       | Phrase-first, topic-fallback; caps at 3 links              |
+| Duplicate detection   | [`src/duplicate-detection.js`](src/duplicate-detection.js) | Jaccard title overlap + shared topic-label count           |
+| Comment rendering     | [`src/triage-format.js`](src/triage-format.js)       | Two-audience: reporter-facing on top, team details collapsed |
+| GitHub REST helpers   | [`src/github.js`](src/github.js)                     | Native `fetch`, pagination, idempotency marker             |
+| Single-issue entry    | [`scripts/triage-single-issue.js`](scripts/triage-single-issue.js) | Used by both workflows                                     |
+
+## Workflows
+
+| Workflow                                                            | Trigger                                                                                   | What it does                       |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| [`agent-triage.yml`](.github/workflows/agent-triage.yml)             | `issues: opened`, `issues: reopened`, or `workflow_dispatch` with an `issue_number` input | Triages one issue                  |
+| [`agent-triage-batch.yml`](.github/workflows/agent-triage-batch.yml) | Cron `17 3 * * *`, `workflow_dispatch`, or `push` to `main` touching `src/**` / the batch workflow | Finds all untriaged open issues and triages each one |
+
+The `push`-to-main trigger means a one-time merge of this PR (or any update
+to the bot's source) will automatically backfill across all open issues — no
+manual `workflow_dispatch` needed.
+
+## Idempotency
+
+Every comment the bot posts begins with the marker `<!-- agentry:triage -->`.
+Before posting, the bot checks the issue's existing comments for this marker
+and skips if it's already there. So re-running the workflow on the same issue
+is safe and a no-op.
+
+## Labels used (separate namespace from FabricBot)
+
+- `agent:triaged` — bookkeeping; presence means the bot ran
+- `category:bug`, `category:feature-request`, `category:question`, `category:documentation`, `category:security`, `category:performance`, `category:enhancement`
+- `severity:critical`, `severity:high`, `severity:medium`, `severity:low`, `severity:info`
+- `next-step:close-as-by-design`, `next-step:close-as-duplicate`, `next-step:close-as-fixed`, `next-step:run-azure-repro`, `next-step:needs-product-decision`, `next-step:needs-docs-update`, `next-step:needs-more-info`, `next-step:escalate-security`, `next-step:keep-open-tracking`
+- `topic:*` — light-grey topic markers (e.g. `topic:denySettings`, `topic:action-on-unmanage`)
+
+These do **not** overlap with the FabricBot policy in
+[`.github/policies/resourceManagement.yml`](.github/policies/resourceManagement.yml),
+which uses the `Needs: *` / `Status: *` namespace.
+
+## Age awareness
+
+The bot adjusts its tone based on how long an issue has been open:
+
+| Age band  | Definition  | Opener                                                                                     |
+| --------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `recent`  | < 30 days   | "Hi, and thanks for opening this issue."                                                  |
+| `aging`   | 30–179 days | (same as recent)                                                                          |
+| `stale`   | 180–729 days | "Thanks for your patience on this one."                                                   |
+| `very-old`| ≥ 730 days  | "Apologies for the long wait on this one. … recently picked up as an outstanding open issue" |
+
+Stale and very-old issues also get a "**Still relevant?**" section inviting
+the reporter to confirm whether the issue still reproduces.
+
+## Rollback
+
+This bot writes only **labels and one comment per issue**. Nothing destructive,
+nothing on closed issues. To disable:
+
+```bash
+gh workflow disable "Agent — triage on issue open" --repo Azure/deployment-stacks
+gh workflow disable "Agent — nightly batch triage" --repo Azure/deployment-stacks
+```
+
+To fully remove, delete [`src/`](src/), [`scripts/triage-single-issue.js`](scripts/triage-single-issue.js),
+and the two workflow files.
+
+## Local development
+
+```bash
+# Requires Node 20+. No npm install needed (zero deps).
+node --check src/*.js
+node --check scripts/*.js
+
+# Triage a single issue locally (read-only by default unless you have write perms):
+GITHUB_TOKEN=$(gh auth token) \
+  GITHUB_REPOSITORY=Azure/deployment-stacks \
+  ISSUE_NUMBER=123 \
+  node scripts/triage-single-issue.js
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "deployment-stacks-triage-bot",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Deterministic, no-AI issue triage assistant for the Azure Deployment Stacks repo.",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/scripts/triage-single-issue.js
+++ b/scripts/triage-single-issue.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Triage a single issue and post a comment + labels.
+// Idempotent: skips if the triage marker is already present on the issue.
+//
+// Usage:
+//   ISSUE_NUMBER=12 node scripts/triage-single-issue.js
+//   node scripts/triage-single-issue.js 12
+//
+// Required env:
+//   GITHUB_TOKEN          - PAT or GITHUB_TOKEN with issues:write
+//   GITHUB_REPOSITORY     - owner/repo (e.g. Azure/deployment-stacks)
+//   ISSUE_NUMBER          - issue number to triage (or pass as argv[2])
+
+import {
+  assertWritableRepo,
+  getIssue,
+  listComments,
+  listOpenIssues,
+  hasMarkerComment,
+  postComment,
+  addLabels,
+} from '../src/github.js';
+import { triageIssue } from '../src/heuristic-triage.js';
+import {
+  formatTriageComment,
+  triageLabels,
+  findExistingLabelConflicts,
+} from '../src/triage-format.js';
+import { docsForTopics, selectDocsLinks } from '../src/docs-pointers.js';
+import { findPossibleDuplicates } from '../src/duplicate-detection.js';
+
+function getEnv(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing environment variable: ${name}`);
+  return v;
+}
+
+async function main() {
+  const token = getEnv('GITHUB_TOKEN');
+  const repo = getEnv('GITHUB_REPOSITORY').toLowerCase();
+  const issueNumberArg = process.env.ISSUE_NUMBER || process.argv[2];
+  if (!issueNumberArg) {
+    throw new Error('Missing ISSUE_NUMBER env var or first arg.');
+  }
+  const issueNumber = Number(issueNumberArg);
+  if (!Number.isInteger(issueNumber)) {
+    throw new Error(`Invalid issue number: ${issueNumberArg}`);
+  }
+
+  // Hard refusal to write to upstream.
+  assertWritableRepo(repo);
+
+  // Idempotency check.
+  if (await hasMarkerComment(token, repo, issueNumber)) {
+    console.log(`Issue #${issueNumber} already triaged — skipping.`);
+    return;
+  }
+
+  const issue = await getIssue(token, repo, issueNumber);
+  if (issue.pull_request) {
+    console.log(`#${issueNumber} is a pull request, not an issue. Skipping.`);
+    return;
+  }
+
+  const comments = await listComments(token, repo, issueNumber);
+
+  console.log(`Triaging #${issueNumber}: "${issue.title}" (${comments.length} comments)`);
+  const result = triageIssue(issue, comments);
+
+  // Look up topic-based docs links + check for possible duplicates among
+  // the other open issues in the repo.
+  const blob = [
+    issue.title || '',
+    issue.body || '',
+    ...comments.map(c => c.body || ''),
+  ].join('\n');
+  const docsLinks = selectDocsLinks(blob, result.detected_topics);
+  let possibleDuplicates = [];
+  try {
+    const otherIssues = await listOpenIssues(token, repo);
+    possibleDuplicates = findPossibleDuplicates(issue, result.detected_topics, otherIssues);
+  } catch (err) {
+    console.warn(`  warning: duplicate detection skipped: ${err.message}`);
+  }
+  const existingLabelConflicts = findExistingLabelConflicts(issue.labels, result);
+
+  const body = formatTriageComment(result, {
+    docsLinks,
+    possibleDuplicates,
+    existingLabelConflicts,
+  });
+  const labels = triageLabels(result);
+
+  console.log(`  category=${result.category} severity=${result.severity} next-step=${result.recommended_next_step} confidence=${result.confidence}`);
+  console.log(`  rules:  ${result.rules_fired.length}`);
+  console.log(`  topics: ${result.detected_topics.join(', ') || '(none)'}`);
+  console.log(`  docs:   ${docsLinks.length} link${docsLinks.length === 1 ? '' : 's'}`);
+  console.log(`  dupes:  ${possibleDuplicates.length ? possibleDuplicates.map(d => `#${d.number}`).join(', ') : '(none)'}`);
+  if (existingLabelConflicts.length) {
+    console.log(`  ⚠ label conflicts: ${existingLabelConflicts.join(', ')}`);
+  }
+
+  await postComment(token, repo, issueNumber, body);
+  await addLabels(token, repo, issueNumber, labels);
+
+  console.log(`Triage posted on #${issueNumber}.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/docs-pointers.js
+++ b/src/docs-pointers.js
@@ -1,0 +1,157 @@
+// Topic + phrase → canonical learn.microsoft.com docs mapping.
+//
+// All URLs in this file were verified to return HTTP 200 on 2026-05-26.
+// Only top-level / stable URLs are used (no deep anchors) so they survive
+// docs reorgs.
+//
+// Selection priority:
+//   1. Phrase matches against the issue's full text blob (title + body + comments)
+//      — most specific, surfaced first.
+//   2. Topic-label matches (from the classifier's detected_topics).
+//   3. Dedup and cap at MAX_LINKS so we don't spam.
+
+const MAX_LINKS = 3;
+
+// Phrase patterns — these are highly specific signals where we know the exact
+// doc page that helps. Tested against the full blob.
+const PHRASE_DOCS = [
+  {
+    pattern: /denysettings|denyassignment/i,
+    label: 'Deployment stacks: protect managed resources (deny settings)',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks',
+    weight: 100,
+  },
+  {
+    pattern: /actiononunmanage|action[\s-]?on[\s-]?unmanage|--action-on-unmanage|delete[\s-]?all|detach[\s-]?all|deleteresources/i,
+    label: 'Deployment stacks: action on unmanage (detach vs delete)',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks',
+    weight: 95,
+  },
+  {
+    pattern: /private[\s-]?dns[\s-]?zone|privatednszones/i,
+    label: 'Azure Private DNS zones overview',
+    url: 'https://learn.microsoft.com/azure/dns/private-dns-overview',
+    weight: 90,
+  },
+  {
+    pattern: /az\s+stack\b|--action-on-unmanage|az\s+deployment\s+stack/i,
+    label: 'az stack — Azure CLI command reference',
+    url: 'https://learn.microsoft.com/cli/azure/stack',
+    weight: 85,
+  },
+  {
+    pattern: /new-azsubscriptiondeploymentstack|new-azmanagementgroupdeploymentstack|new-azresourcegroupdeploymentstack|az\.resources|\baz\s+powershell\b/i,
+    label: 'Az.Resources reference (deployment stack cmdlets)',
+    url: 'https://learn.microsoft.com/powershell/module/az.resources/',
+    weight: 80,
+  },
+  {
+    pattern: /managed[\s-]?identity|user[\s-]?assigned[\s-]?identity|userassignedidentity/i,
+    label: 'Managed identities for Azure resources — overview',
+    url: 'https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview',
+    weight: 70,
+  },
+  {
+    pattern: /role[\s-]?assignment|microsoft\.authorization\/roleassignments/i,
+    label: 'Microsoft.Authorization/roleAssignments — template reference',
+    url: 'https://learn.microsoft.com/azure/templates/microsoft.authorization/roleassignments',
+    weight: 70,
+  },
+  {
+    pattern: /\.bicep\b|bicep[\s-]?module|bicep[\s-]?file|bicep[\s-]?language/i,
+    label: 'Bicep language — overview',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview',
+    weight: 60,
+  },
+];
+
+// Topic-label fallback — broader, applies when phrase didn't fire.
+const TOPIC_DOCS = {
+  'denySettings': {
+    label: 'Deployment stacks overview',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks',
+    weight: 50,
+  },
+  'action-on-unmanage': {
+    label: 'Deployment stacks overview',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks',
+    weight: 50,
+  },
+  'role-assignment': {
+    label: 'Microsoft.Authorization/roleAssignments — template reference',
+    url: 'https://learn.microsoft.com/azure/templates/microsoft.authorization/roleassignments',
+    weight: 50,
+  },
+  'managed-identity': {
+    label: 'Managed identities for Azure resources — overview',
+    url: 'https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview',
+    weight: 50,
+  },
+  'bicep-language': {
+    label: 'Bicep language — overview',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview',
+    weight: 40,
+  },
+  'az-cli': {
+    label: 'az stack — Azure CLI command reference',
+    url: 'https://learn.microsoft.com/cli/azure/stack',
+    weight: 40,
+  },
+  'powershell-az': {
+    label: 'Az.Resources reference (deployment stack cmdlets)',
+    url: 'https://learn.microsoft.com/powershell/module/az.resources/',
+    weight: 40,
+  },
+  'private-dns-zone': {
+    label: 'Azure Private DNS zones overview',
+    url: 'https://learn.microsoft.com/azure/dns/private-dns-overview',
+    weight: 40,
+  },
+  'portal': {
+    label: 'Deployment stacks overview',
+    url: 'https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks',
+    weight: 30,
+  },
+};
+
+// Selects up to MAX_LINKS docs links for the given issue context, prioritizing
+// phrase matches over topic matches, deduped by URL.
+//
+// Inputs:
+//   - blob: title + body + comments concatenated (same blob the classifier uses)
+//   - topics: detected_topics array
+export function selectDocsLinks(blob, topics) {
+  const candidates = [];
+
+  // 1. Phrase matches (most specific first)
+  for (const d of PHRASE_DOCS) {
+    if (d.pattern.test(blob || '')) {
+      candidates.push({ label: d.label, url: d.url, weight: d.weight, source: 'phrase' });
+    }
+  }
+
+  // 2. Topic-label fallbacks
+  for (const topic of topics || []) {
+    const d = TOPIC_DOCS[topic];
+    if (d) {
+      candidates.push({ label: d.label, url: d.url, weight: d.weight, source: `topic:${topic}` });
+    }
+  }
+
+  // Sort by weight desc, then dedup by URL preserving first occurrence.
+  candidates.sort((a, b) => b.weight - a.weight);
+  const seen = new Set();
+  const out = [];
+  for (const c of candidates) {
+    if (seen.has(c.url)) continue;
+    seen.add(c.url);
+    out.push({ label: c.label, url: c.url });
+    if (out.length >= MAX_LINKS) break;
+  }
+  return out;
+}
+
+// Back-compat wrapper for callers that only know about topics.
+export function docsForTopics(topics) {
+  return selectDocsLinks('', topics);
+}

--- a/src/duplicate-detection.js
+++ b/src/duplicate-detection.js
@@ -1,0 +1,103 @@
+// Lightweight, deterministic duplicate / near-duplicate detection.
+//
+// Approach:
+//   1. Tokenize titles after lowercasing + stripping any leading `[#NNN]` prefix.
+//   2. Drop English stopwords and short tokens.
+//   3. Compute Jaccard similarity between candidate and each other open issue.
+//   4. Also count shared detected topics.
+//   5. Require BOTH meaningful title overlap AND topic overlap to declare a
+//      possible duplicate. The bot only *suggests* — humans confirm/close.
+//
+// We never claim duplicates with high confidence on title overlap alone — many
+// Deployment Stacks issues share words like "deployment", "stack", "delete".
+
+const STOPWORDS = new Set([
+  'a','an','and','are','as','at','be','by','for','from','has','have','i','if',
+  'in','is','it','its','of','on','or','that','the','their','then','this','to',
+  'was','were','will','with','you','your','my','we','our','us','me','can','do',
+  'does','did','not','no','yes','but','so','than','via','using','use','used',
+  'when','what','why','how','who','where','which','should','would','could','may',
+  'might','must','about','any','some','all','more','less','also','out','up',
+  // Common deployment-stacks domain words that don't actually disambiguate:
+  'deployment','deployments','stack','stacks','azure','arm','resource','resources',
+  'issue','issues','bug','feature','request','support','error','please','help',
+]);
+
+function tokenize(text) {
+  return (text || '')
+    .toLowerCase()
+    .replace(/^\s*\[#\d+\]\s*/, '')                  // drop any leading `[#NNN]` prefix
+    .replace(/[`*_~>#\-—–\(\)\[\]\{\}.,:;!?"/\\]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+function jaccard(a, b) {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+// Returns up to 2 suggestions sorted by combined score, each:
+//   { number, title, score, sharedTopics, sharedTokens, reason }
+export function findPossibleDuplicates(currentIssue, currentTopics, otherIssues) {
+  if (!Array.isArray(otherIssues) || otherIssues.length === 0) return [];
+
+  const myTokens = new Set(tokenize(currentIssue.title));
+  const myTopics = new Set(currentTopics || []);
+  if (myTokens.size === 0) return [];
+
+  const scored = [];
+  for (const other of otherIssues) {
+    if (!other || other.number === currentIssue.number) continue;
+    if (other.state && other.state !== 'open') continue;
+    if (other.pull_request) continue;
+
+    const otherTokens = new Set(tokenize(other.title));
+    if (otherTokens.size === 0) continue;
+
+    // Topic overlap: how many topic labels does the OTHER issue have in common
+    // (we approximate by checking topic-label names against the issue's labels).
+    const otherTopicLabels = (other.labels || [])
+      .map(l => (typeof l === 'string' ? l : l.name) || '')
+      .filter(name => name.startsWith('topic:'))
+      .map(name => name.slice('topic:'.length));
+
+    const sharedTopics = otherTopicLabels.filter(t => myTopics.has(t));
+    const tokenJaccard = jaccard(myTokens, otherTokens);
+
+    // Heuristic threshold:
+    //   - jaccard >= 0.35 alone is suggestive but noisy
+    //   - >= 1 shared topic + jaccard >= 0.2 is a much stronger signal
+    let score = 0;
+    let reason = null;
+    if (sharedTopics.length >= 2 && tokenJaccard >= 0.15) {
+      score = tokenJaccard + 0.15 * sharedTopics.length;
+      reason = `shares ${sharedTopics.length} topic labels (${sharedTopics.join(', ')}) and title overlap ${Math.round(tokenJaccard * 100)}%`;
+    } else if (sharedTopics.length >= 1 && tokenJaccard >= 0.25) {
+      score = tokenJaccard + 0.10 * sharedTopics.length;
+      reason = `shares topic \`${sharedTopics[0]}\` and title overlap ${Math.round(tokenJaccard * 100)}%`;
+    } else if (tokenJaccard >= 0.45) {
+      score = tokenJaccard;
+      reason = `strong title overlap (${Math.round(tokenJaccard * 100)}%)`;
+    }
+
+    if (score > 0) {
+      const sharedTokensList = [...myTokens].filter(t => otherTokens.has(t)).slice(0, 6);
+      scored.push({
+        number: other.number,
+        title: other.title,
+        url: other.html_url,
+        score,
+        sharedTopics,
+        sharedTokens: sharedTokensList,
+        reason,
+      });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, 2);
+}

--- a/src/github.js
+++ b/src/github.js
@@ -1,0 +1,163 @@
+// Pure-Node ESM GitHub REST helpers + privacy guard.
+// Zero third-party dependencies — relies on Node 20+ built-in fetch.
+
+const GITHUB_API = 'https://api.github.com';
+
+// Hard guard: deny-list for any repos the agent must never write to.
+// Repo names are compared lowercased.
+// Empty by default in production; populate locally to firewall test repos.
+const FORBIDDEN_WRITE_REPOS = new Set([]);
+
+export function assertWritableRepo(repo) {
+  if (!repo) {
+    throw new Error('assertWritableRepo: missing repo (expected "owner/name").');
+  }
+  if (FORBIDDEN_WRITE_REPOS.has(repo.toLowerCase())) {
+    throw new Error(
+      `Privacy guard: refusing to write to ${repo}. ` +
+      `This repo is in FORBIDDEN_WRITE_REPOS.`
+    );
+  }
+}
+
+// Idempotency marker — every triage comment includes this so repeat runs skip it.
+export const TRIAGE_MARKER = '<!-- agentry:triage -->';
+
+export const LABEL_COLORS = {
+  // Bookkeeping
+  'agent:triaged': '5319e7',
+
+  // Categories
+  'category:bug':             'd73a4a',
+  'category:feature-request': 'a2eeef',
+  'category:question':        'd876e3',
+  'category:documentation':   '0075ca',
+  'category:security':        'b60205',
+  'category:performance':     'fbca04',
+  'category:enhancement':     'cfd3d7',
+
+  // Severities
+  'severity:critical': 'b60205',
+  'severity:high':     'd93f0b',
+  'severity:medium':   'fbca04',
+  'severity:low':      '0e8a16',
+  'severity:info':     'c5def5',
+
+  // Next steps
+  'next-step:close-as-by-design':     '0e8a16',
+  'next-step:close-as-duplicate':     '0e8a16',
+  'next-step:close-as-fixed':         '0e8a16',
+  'next-step:run-azure-repro':        'fbca04',
+  'next-step:needs-product-decision': '5319e7',
+  'next-step:needs-docs-update':      '0075ca',
+  'next-step:needs-more-info':        'fbca04',
+  'next-step:escalate-security':      'b60205',
+  'next-step:keep-open-tracking':     'c5def5',
+
+  // Topics (all light grey)
+  'topic:denySettings':          'ededed',
+  'topic:action-on-unmanage':    'ededed',
+  'topic:delete-failure':        'ededed',
+  'topic:role-assignment':       'ededed',
+  'topic:managed-identity':      'ededed',
+  'topic:bicep-language':        'ededed',
+  'topic:az-cli':                'ededed',
+  'topic:powershell-az':         'ededed',
+  'topic:private-dns-zone':      'ededed',
+  'topic:by-design':             'ededed',
+  'topic:known-limitation':      'ededed',
+  'topic:pipeline':              'ededed',
+  'topic:error-message-quality': 'ededed',
+  'topic:portal':                'ededed',
+};
+
+function ghHeaders(token) {
+  return {
+    'Accept':              'application/vnd.github+json',
+    'Authorization':       `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent':          'deployment-stacks-triage-bot',
+  };
+}
+
+async function ghFetch(token, method, path, body) {
+  const url = path.startsWith('http') ? path : `${GITHUB_API}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      ...ghHeaders(token),
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub ${method} ${path} -> ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export async function paginate(token, path) {
+  const out = [];
+  let next = `${path}${path.includes('?') ? '&' : '?'}per_page=100`;
+  while (next) {
+    const url = next.startsWith('http') ? next : `${GITHUB_API}${next}`;
+    const res = await fetch(url, { headers: ghHeaders(token) });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub GET ${url} -> ${res.status}: ${text}`);
+    }
+    const page = await res.json();
+    out.push(...page);
+    const link = res.headers.get('link');
+    const m = link?.match(/<([^>]+)>;\s*rel="next"/);
+    next = m ? m[1] : null;
+  }
+  return out;
+}
+
+export async function getIssue(token, repo, number) {
+  return ghFetch(token, 'GET', `/repos/${repo}/issues/${number}`);
+}
+
+export async function listComments(token, repo, number) {
+  return paginate(token, `/repos/${repo}/issues/${number}/comments`);
+}
+
+export async function hasMarkerComment(token, repo, number) {
+  const comments = await listComments(token, repo, number);
+  return comments.some(c => (c.body || '').includes(TRIAGE_MARKER));
+}
+
+export async function postComment(token, repo, number, body) {
+  assertWritableRepo(repo);
+  return ghFetch(token, 'POST', `/repos/${repo}/issues/${number}/comments`, { body });
+}
+
+export async function ensureLabel(token, repo, name) {
+  assertWritableRepo(repo);
+  const color = LABEL_COLORS[name] || 'ededed';
+  try {
+    await ghFetch(token, 'POST', `/repos/${repo}/labels`, {
+      name,
+      color,
+      description: 'Auto-created by triage agent.',
+    });
+  } catch (err) {
+    // 422 Unprocessable Entity = label already exists. Ignore.
+    if (!/422/.test(err.message)) throw err;
+  }
+}
+
+export async function addLabels(token, repo, number, labels) {
+  assertWritableRepo(repo);
+  for (const l of labels) await ensureLabel(token, repo, l);
+  return ghFetch(token, 'POST', `/repos/${repo}/issues/${number}/labels`, { labels });
+}
+
+// Returns all open issues in the repo (NOT PRs). Used for duplicate detection.
+export async function listOpenIssues(token, repo) {
+  const items = await paginate(token, `/repos/${repo}/issues?state=open`);
+  return items.filter(i => !i.pull_request);
+}

--- a/src/heuristic-triage.js
+++ b/src/heuristic-triage.js
@@ -1,0 +1,359 @@
+// Pure-Node deterministic issue classifier for Azure Deployment Stacks.
+//
+// Input: issue object (title, body) and array of comments.
+// Output: classification object with:
+//   - category, severity, summary, suggested_action
+//   - recommended_next_step (string enum)
+//   - confidence ('low' | 'medium' | 'high')
+//   - rules_fired (array of human-readable rule descriptions)
+//   - detected_topics (array of topic slugs)
+//
+// Design principle: every classification is traceable to a specific rule.
+// No AI calls. No external dependencies.
+
+const TOPIC_RULES = [
+  { topic: 'denySettings',          pattern: /deny[\s-]?settings|denyassignment|deny[\s-]?assignment/i },
+  { topic: 'action-on-unmanage',    pattern: /action[\s-]?on[\s-]?unmanage|actiononunmanage|delete[\s-]?all|detach[\s-]?all|deleteresources/i },
+  { topic: 'delete-failure',        pattern: /delete[\s-]?fail|cannot[\s-]?delete|won'?t[\s-]?delete|stuck.{0,40}delet|deletion[\s-]?failure|fail.{0,30}delet/i },
+  { topic: 'role-assignment',       pattern: /role[\s-]?assignment|microsoft\.authorization\/roleassignments/i },
+  { topic: 'managed-identity',      pattern: /managed[\s-]?identity|user[\s-]?assigned[\s-]?identity|userassignedidentity/i },
+  { topic: 'bicep-language',        pattern: /\bbicep\b/i },
+  { topic: 'az-cli',                pattern: /\baz cli\b|\baz stack\b|\baz deployment\b|--action-on-unmanage|azure[\s-]?cli/i },
+  { topic: 'powershell-az',         pattern: /azure[\s-]?powershell|\baz\.resources\b|new-az\w*deploymentstack|powershell\s+cmdlet/i },
+  { topic: 'private-dns-zone',      pattern: /private[\s-]?dns[\s-]?zone|privatednszones/i },
+  { topic: 'by-design',             pattern: /by[\s-]?design|expected[\s-]?behavior|working[\s-]?as[\s-]?designed/i },
+  { topic: 'known-limitation',      pattern: /known[\s-]?issue|known[\s-]?limitation|documented[\s-]?limitation/i },
+  { topic: 'pipeline',              pattern: /azure[\s-]?devops|github[\s-]?actions|ado[\s-]?agent|self[\s-]?hosted[\s-]?agent|\bpipeline\b|docker[\s-]?container/i },
+  { topic: 'error-message-quality', pattern: /error[\s-]?message|better[\s-]?error|unclear[\s-]?error|cryptic|misleading|add a errormessage/i },
+  { topic: 'portal',                pattern: /azure[\s-]?portal|portal\.azure\.com/i },
+];
+
+function detectTopics(blob) {
+  return TOPIC_RULES.filter(r => r.pattern.test(blob)).map(r => r.topic);
+}
+
+function detectCategory(title, body, blob, rulesFired) {
+  // Drop any leading `[#NNN]` prefix so title patterns still match cleanly.
+  const cleanTitle = (title || '').replace(/^\s*\[#\d+\]\s*/, '');
+
+  // 1. Security (highest priority)
+  if (/security[\s-]?(issue|vuln)|\bcve-\d{4}|credential[\s-]?leak|secret[\s-]?exposure|exposed[\s-]?secret/i.test(blob)) {
+    rulesFired.push('category=security (security keyword matched)');
+    return 'security';
+  }
+
+  // 2. Documentation
+  if (/(\bdocs?\b|documentation).{0,30}(wrong|missing|outdated|unclear|broken)/i.test(blob)
+   || /where (is|are) (the )?docs?|is this documented/i.test(blob)) {
+    rulesFired.push('category=documentation (doc-related keywords)');
+    return 'documentation';
+  }
+
+  // 3. Feature request — three signals:
+  //    (a) feature-template heading in body
+  //    (b) explicit prefix on title: "feature:", "[FR]", etc.
+  //    (c) title verbs that strongly imply asking for new capability:
+  //        "Introduce X API", "Add X cmdlet", "Support X", "Expose X",
+  //        "Parallelize X", "Granular control for X", "Missing X", "History of X".
+  //        These intent verbs override the bug-template check below so titles
+  //        like "Introduce Deployment Stack Cancel API" don't get mis-routed.
+  const featureHeading = /(?:^|\n)#+\s*Is your feature request related to a problem|\*\*Is your feature request related to a problem\?\*\*|(?:^|\n)#+\s*Describe the solution you'd like|\*\*Describe the solution you'?d like\*\*/i;
+  const featureTitlePrefix = /^\s*(\[(feature|fr|feature[\s-]?request)\]|feature\s*request:|feature:|fr:)/i;
+  const featureTitleIntent = /^\s*(introduce|add|expose|enable|allow)\s+[\w\s\-]{2,80}\b(api|cmdlet|command|flag|parameter|option|property|capability|sdk|client)\b/i;
+  const featureTitleShape = /^\s*(parallelize|granular\s+control|history\s+of|missing\s+(new\s+)?features?|support\s+for)\b/i;
+  if (
+    featureHeading.test(body)
+    || featureTitlePrefix.test(cleanTitle)
+    || featureTitleIntent.test(cleanTitle)
+    || featureTitleShape.test(cleanTitle)
+  ) {
+    if (featureHeading.test(body)) {
+      rulesFired.push('category=feature-request (feature-request template heading in body)');
+    } else if (featureTitlePrefix.test(cleanTitle)) {
+      rulesFired.push("category=feature-request (title prefix like 'feature:' / '[FR]')");
+    } else if (featureTitleIntent.test(cleanTitle)) {
+      rulesFired.push('category=feature-request (title verb implies new capability: introduce/add/expose/enable/allow … api/cmdlet/command/etc.)');
+    } else {
+      rulesFired.push('category=feature-request (title shape: parallelize / granular control / history of / missing / support for)');
+    }
+    return 'feature-request';
+  }
+
+  // 4. Bug (issue template marker or traceback)
+  const bugHeading = /(?:^|\n)#+\s*Describe the bug|\*\*Describe the bug\*\*|(?:^|\n)#+\s*Repro Environment|\*\*Repro Environment\*\*/i;
+  if (bugHeading.test(body) || /traceback \(most recent call last\)/i.test(blob)) {
+    rulesFired.push('category=bug (template heading or traceback)');
+    return 'bug';
+  }
+
+  // 5. Performance
+  if (/\b(too )?slow\b|\btimeout\b|takes (way )?too long|performance[\s-]?(issue|problem)|reduce the time/i.test(blob)) {
+    rulesFired.push('category=performance (slow/timeout keyword)');
+    return 'performance';
+  }
+
+  // 6. Question (title ends with ?)
+  if (/\?$/.test(cleanTitle.trim())) {
+    rulesFired.push("category=question (title ends with '?')");
+    return 'question';
+  }
+
+  // 7. Enhancement (improvement language)
+  if (/would be (great|nice|good)|could.{0,20}(improve|enhance|add)|missing[\s-]?feature|please[\s-]?(add|support)/i.test(blob)) {
+    rulesFired.push('category=enhancement (improvement language)');
+    return 'enhancement';
+  }
+
+  // Default
+  rulesFired.push('category=question (default fallback)');
+  return 'question';
+}
+
+function detectSeverity(blob, category, rulesFired) {
+  if (/data[\s-]?loss|destroyed|deleted my prod|prod(uction)?[\s-]?(outage|down)/i.test(blob)) {
+    rulesFired.push('severity=critical (data-loss/outage signal)');
+    return 'critical';
+  }
+  if (/blocked|cannot deploy|can'?t deploy|regression|stopped working|broken in (production|prod)/i.test(blob)) {
+    rulesFired.push('severity=high (blocker/regression signal)');
+    return 'high';
+  }
+  if (category === 'bug' && /workaround|work[\s-]?around|fixed by|fix was/i.test(blob)) {
+    rulesFired.push('severity=medium (bug with stated workaround)');
+    return 'medium';
+  }
+  if (category === 'bug') {
+    rulesFired.push('severity=medium (default for bug)');
+    return 'medium';
+  }
+  if (category === 'performance') {
+    rulesFired.push('severity=medium (default for performance)');
+    return 'medium';
+  }
+  rulesFired.push(`severity=info (default for ${category})`);
+  return 'info';
+}
+
+function recommendNextStep(category, topics, blob, comments, rulesFired) {
+  // Security always escalates first.
+  if (category === 'security') {
+    rulesFired.push('next-step=escalate-security (category=security)');
+    return 'escalate-security';
+  }
+
+  // Reporter signaled resolution.
+  const resolutionRe = /that fixes (the |my )?(error|issue|problem)|that worked|fixed it|you can.{0,20}close|please close|close (this|it) (ticket|issue)|fix was/i;
+  if (resolutionRe.test(blob)) {
+    rulesFired.push('next-step=close-as-fixed (reporter signaled resolution)');
+    return 'close-as-fixed';
+  }
+
+  // Known limitations / by-design — only short-circuit for bug/question.
+  // A feature request that happens to *mention* "by design" (e.g., "this is
+  // currently by design, but we'd like X") should still be tracked as a
+  // feature request, not auto-closed.
+  if ((category === 'bug' || category === 'question') &&
+      (topics.includes('by-design') || topics.includes('known-limitation'))) {
+    rulesFired.push(`next-step=close-as-by-design (by-design/known-limitation topic on ${category})`);
+    return 'close-as-by-design';
+  }
+
+  if (category === 'documentation') {
+    rulesFired.push('next-step=needs-docs-update (category=documentation)');
+    return 'needs-docs-update';
+  }
+
+  if (category === 'feature-request' || category === 'enhancement') {
+    rulesFired.push(`next-step=keep-open-tracking (category=${category})`);
+    return 'keep-open-tracking';
+  }
+
+  if (category === 'question') {
+    const teamReplied = comments.some(c =>
+      ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(c.author_association || '')
+    );
+    if (teamReplied) {
+      rulesFired.push('next-step=needs-product-decision (question, team already engaged)');
+      return 'needs-product-decision';
+    }
+    rulesFired.push('next-step=needs-more-info (unanswered question)');
+    return 'needs-more-info';
+  }
+
+  if (category === 'bug') {
+    const hasCorrelationId = /correlation[\s-]?id\s*[":=]+\s*\"?\S{8,}/i.test(blob);
+    const hasVersion = /az\s+version|az\s+v\d|az[\s-]?cli\s+v\d|powershell\s+(version|v\d)|host\s+os\s*:?\s*\S+|version[:\s]+\d/i.test(blob);
+    if (!hasCorrelationId && !hasVersion) {
+      rulesFired.push('next-step=needs-more-info (bug missing correlation ID and version)');
+      return 'needs-more-info';
+    }
+    rulesFired.push('next-step=run-azure-repro (bug has enough info for repro)');
+    return 'run-azure-repro';
+  }
+
+  if (category === 'performance') {
+    rulesFired.push('next-step=keep-open-tracking (performance issue)');
+    return 'keep-open-tracking';
+  }
+
+  rulesFired.push('next-step=keep-open-tracking (default fallback)');
+  return 'keep-open-tracking';
+}
+
+function buildSummary(issue, category, topics) {
+  const titlePart = (issue.title || '').replace(/^\[#\d+\]\s*/, '').slice(0, 140);
+  const topicHint = topics.length ? ` Topics: ${topics.slice(0, 3).join(', ')}.` : '';
+  return `${category} — ${titlePart}.${topicHint}`;
+}
+
+function buildSuggestedAction(category, nextStep, topics) {
+  switch (nextStep) {
+    case 'close-as-by-design':
+      return 'Verify against current documented behavior, link the docs/known-issues page in a friendly close-out comment, and close.';
+    case 'close-as-fixed':
+      return 'Reporter signaled resolution. Thank them, optionally note the underlying fix in a follow-up comment, and close.';
+    case 'close-as-duplicate':
+      return 'Link the duplicate, copy any unique context to the canonical issue, and close.';
+    case 'needs-docs-update':
+      return 'Confirm the doc gap, file an internal docs work item (or open a learn.microsoft.com PR), and update the issue with a link.';
+    case 'needs-more-info':
+      return 'Ask the reporter for missing info: correlation ID, az / Az PowerShell version, exact command, and timestamp + timezone.';
+    case 'needs-product-decision':
+      return `Pull into next product sync. Classifier detected ${topics.length ? `topics ${topics.join(', ')}` : 'no specific topics'} — confirm scope before responding.`;
+    case 'run-azure-repro':
+      return 'Bug has enough info (correlation ID or version present). Spin up a repro env, validate, and post findings.';
+    case 'escalate-security':
+      return 'Treat as security-sensitive. Do NOT discuss specifics in public comments. Escalate via internal channel before any public reply.';
+    case 'keep-open-tracking':
+      return category === 'feature-request' || category === 'enhancement'
+        ? 'Add to the feature backlog for product review.'
+        : 'Keep open and check back as the thread evolves.';
+    default:
+      return 'Review and assign manually.';
+  }
+}
+
+// Short, reporter-facing phrasing of the recommended next step.
+// This is what shows in the public "What I noticed" section. No internal jargon.
+function publicNextStepBlurb(nextStep, category) {
+  switch (nextStep) {
+    case 'close-as-by-design':
+      return 'A team member will confirm whether this is documented behavior and follow up.';
+    case 'close-as-fixed':
+      return 'It looks like this may already be resolved — a team member will confirm and close.';
+    case 'close-as-duplicate':
+      return 'This may be a duplicate of an existing issue — a team member will link the two.';
+    case 'needs-docs-update':
+      return 'This looks like a docs gap — we\u2019ll review and follow up with a docs link or update.';
+    case 'needs-more-info':
+      return 'We may need a bit more info to reproduce — a team member will ask if anything is unclear.';
+    case 'needs-product-decision':
+      return 'This is a product-direction question — we\u2019ll bring it to the team and respond.';
+    case 'run-azure-repro':
+      return 'A team member will attempt to reproduce in Azure and respond with findings.';
+    case 'escalate-security':
+      return 'Routing to the security review channel — please don\u2019t share repro details publicly until we follow up.';
+    case 'keep-open-tracking':
+      return category === 'feature-request' || category === 'enhancement'
+        ? 'Tracking on the feature backlog. We\u2019ll consider it during planning.'
+        : 'Keeping this open while we follow up.';
+    default:
+      return 'A team member will review and respond.';
+  }
+}
+
+function classifyConfidence(topics, rulesFired) {
+  const usedTemplateHeading = rulesFired.some(r => /template heading/.test(r));
+  if (usedTemplateHeading && topics.length >= 2) return 'high';
+  if (usedTemplateHeading || topics.length >= 1) return 'medium';
+  return 'low';
+}
+
+export function triageIssue(issue, comments = []) {
+  const title = issue.title || '';
+  const body = issue.body || '';
+  const commentsBlob = comments.map(c => c.body || '').join('\n');
+  const blob = `${title}\n${body}\n${commentsBlob}`;
+  const rulesFired = [];
+
+  const topics = detectTopics(blob);
+  if (topics.length) rulesFired.push(`topics matched: ${topics.join(', ')}`);
+
+  const category = detectCategory(title, body, blob, rulesFired);
+  const severity = detectSeverity(blob, category, rulesFired);
+  const recommended = recommendNextStep(category, topics, blob, comments, rulesFired);
+  const confidence = classifyConfidence(topics, rulesFired);
+  const suggested = buildSuggestedAction(category, recommended, topics);
+  const publicBlurb = publicNextStepBlurb(recommended, category);
+  const ageSignals = computeAgeSignals(issue, comments, rulesFired);
+
+  return {
+    category,
+    severity,
+    summary: buildSummary(issue, category, topics),
+    root_cause_hypothesis: null,
+    suggested_action: suggested,
+    public_next_step_blurb: publicBlurb,
+    recommended_next_step: recommended,
+    detected_topics: topics,
+    confidence,
+    age_signals: ageSignals,
+    rules_fired: rulesFired,
+    cli_commands: [],
+    needs_azure_test: category === 'bug' && recommended === 'run-azure-repro',
+    azure_resource_types: ['Microsoft.Resources/deploymentStacks'],
+    test_scenario: null,
+    safe_to_autorun: false,
+  };
+}
+
+// Age awareness — drives tone selection in the formatter. Does NOT change
+// classification; FabricBot already handles auto-stale via the
+// `Needs: Author Feedback` + `Status: No Recent Activity` labels.
+function computeAgeSignals(issue, comments, rulesFired) {
+  const now = Date.now();
+  const created = issue.created_at ? new Date(issue.created_at).getTime() : now;
+  const updated = issue.updated_at ? new Date(issue.updated_at).getTime() : created;
+  const ageDays = Math.max(0, Math.floor((now - created) / 86400000));
+  const lastActivityDays = Math.max(0, Math.floor((now - updated) / 86400000));
+
+  const reporterLogin = issue.user && issue.user.login;
+  let lastReporterAct = created;
+  if (reporterLogin) {
+    for (const c of comments) {
+      if (c.user && c.user.login === reporterLogin && c.created_at) {
+        const t = new Date(c.created_at).getTime();
+        if (t > lastReporterAct) lastReporterAct = t;
+      }
+    }
+  }
+  const lastReporterDays = Math.max(0, Math.floor((now - lastReporterAct) / 86400000));
+
+  const teamReplied = comments.some(c =>
+    ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(c.author_association || '')
+  );
+
+  const ageBand =
+    ageDays >= 730 ? 'very-old' :
+    ageDays >= 180 ? 'stale' :
+    ageDays >= 30  ? 'aging' :
+                     'recent';
+
+  // Stale issue with team already engaged but reporter silent → useful signal
+  // for "ping reporter / consider closing."
+  const stalledOnReporter =
+    ageDays >= 60 && teamReplied && lastReporterDays >= 60;
+
+  rulesFired.push(
+    `age_signals: age=${ageDays}d (${ageBand}), last_activity=${lastActivityDays}d, last_reporter=${lastReporterDays}d${stalledOnReporter ? ', stalled-on-reporter' : ''}`
+  );
+
+  return {
+    age_days: ageDays,
+    last_activity_days: lastActivityDays,
+    last_reporter_activity_days: lastReporterDays,
+    age_band: ageBand,
+    team_replied: teamReplied,
+    stalled_on_reporter: stalledOnReporter,
+  };
+}

--- a/src/triage-format.js
+++ b/src/triage-format.js
@@ -1,0 +1,220 @@
+import { TRIAGE_MARKER } from './github.js';
+
+const CONFIDENCE_EMOJI = {
+  high:   '🟢',
+  medium: '🟡',
+  low:    '🔴',
+};
+
+const NEXT_STEP_LABELS = {
+  'close-as-by-design':     'Close — by design',
+  'close-as-duplicate':     'Close — duplicate',
+  'close-as-fixed':         'Close — reporter signaled fixed',
+  'run-azure-repro':        'Run Azure repro',
+  'needs-product-decision': 'Needs product decision',
+  'needs-docs-update':      'Needs docs update',
+  'needs-more-info':        'Needs more info from reporter',
+  'escalate-security':      'Escalate — security',
+  'keep-open-tracking':     'Keep open / tracking',
+};
+
+const CATEGORY_FRIENDLY = {
+  'bug':             'a bug report',
+  'feature-request': 'a feature request',
+  'question':        'a question',
+  'documentation':   'a documentation gap',
+  'security':        'a security report',
+  'performance':     'a performance concern',
+  'enhancement':     'an enhancement request',
+};
+
+// Build the polite, reporter-facing public reply followed by a collapsed
+// "team details" section. `extras` may include:
+//   - docsLinks: [{label, url}]
+//   - possibleDuplicates: [{number, title, url, reason}]
+//   - existingLabelConflicts: ['category:bug'] etc.
+export function formatTriageComment(t, extras = {}) {
+  const conf = CONFIDENCE_EMOJI[t.confidence] || '⚪';
+  const stepLabel = NEXT_STEP_LABELS[t.recommended_next_step] || t.recommended_next_step;
+  const friendlyCategory = CATEGORY_FRIENDLY[t.category] || t.category;
+  const topics = t.detected_topics || [];
+  const docsLinks = extras.docsLinks || [];
+  const dupes = extras.possibleDuplicates || [];
+  const labelConflicts = extras.existingLabelConflicts || [];
+
+  const parts = [];
+
+  parts.push(TRIAGE_MARKER);
+  parts.push('');
+
+  // Opening line is age-aware. Stale and very-old issues lead with an
+  // explicit acknowledgement of the wait.
+  const ageBand = (t.age_signals && t.age_signals.age_band) || 'recent';
+  if (ageBand === 'very-old') {
+    parts.push('👋 **Apologies for the long wait on this one.**');
+    parts.push('');
+    parts.push(
+      "This was recently picked up as an outstanding open issue for the " +
+      "**ARM Deployments team** to review. I'm the team's automated triage " +
+      "assistant \u2014 I've taken a fresh pass at categorizing what you " +
+      "shared so a human reviewer can follow up quickly."
+    );
+  } else if (ageBand === 'stale') {
+    parts.push('👋 **Thanks for your patience on this one.**');
+    parts.push('');
+    parts.push(
+      "We're catching up on older open issues, and the **ARM Deployments " +
+      "team**'s triage assistant has taken a fresh pass at this one. A team " +
+      "member will follow up \u2014 this comment is just to share what I " +
+      "noticed so your issue lands in the right place."
+    );
+  } else {
+    parts.push('👋 **Hi, and thanks for opening this issue.**');
+    parts.push('');
+    parts.push(
+      "I'm an automated triage assistant for the **ARM Deployments team**. " +
+      "To help route your report to the right folks quickly, I've taken a first " +
+      "pass at categorizing what you've shared. A team member will follow up \u2014 " +
+      "this comment is just to share what I noticed so your issue lands in the " +
+      "right place."
+    );
+  }
+  parts.push('');
+
+  // What I noticed (reporter-facing)
+  parts.push('### What I noticed');
+  parts.push('');
+  parts.push(`- This looks like **${friendlyCategory}**.`);
+  if (topics.length) {
+    parts.push(`- Topics detected: ${topics.map(x => `\`${x}\``).join(', ')}`);
+  }
+  parts.push(`- ${t.public_next_step_blurb || 'A team member will review and respond.'}`);
+  parts.push('');
+
+  // Stale-aware ask: if this is an old issue, invite the reporter to confirm
+  // whether it's still relevant before we dig in.
+  if (ageBand === 'stale' || ageBand === 'very-old') {
+    const ageYears = Math.floor((t.age_signals?.age_days || 0) / 365);
+    const ageDesc = ageYears >= 1
+      ? `${ageYears}+ year${ageYears === 1 ? '' : 's'}`
+      : `${Math.round((t.age_signals?.age_days || 0) / 30)} month(s)`;
+    parts.push('### Still relevant?');
+    parts.push('');
+    parts.push(
+      `This issue has been open for ~${ageDesc}. If your situation has changed since ` +
+      `you filed it \u2014 fixed in a newer version of the CLI / Az PowerShell / Bicep, ` +
+      `found a workaround, or no longer reproducing \u2014 a quick reply or close ` +
+      `would help us focus. Otherwise a team member will dig in fresh.`
+    );
+    parts.push('');
+  }
+
+  // Possible duplicates
+  if (dupes.length) {
+    parts.push('### Possibly related to an existing issue');
+    parts.push('');
+    parts.push(
+      "This report shares meaningful overlap with the following open issue" +
+      (dupes.length > 1 ? 's' : '') +
+      ". A team member will confirm whether they should be linked or merged:"
+    );
+    parts.push('');
+    for (const d of dupes) {
+      parts.push(`- **#${d.number}** — ${escapeMd(d.title)}  \n  _Why I think so:_ ${d.reason}.`);
+    }
+    parts.push('');
+  }
+
+  // Helpful docs (reporter-facing)
+  if (docsLinks.length) {
+    parts.push('### Possibly helpful while you wait');
+    parts.push('');
+    parts.push("Some documentation that may be relevant to what you're hitting:");
+    parts.push('');
+    for (const d of docsLinks) {
+      parts.push(`- 📘 [${d.label}](${d.url})`);
+    }
+    parts.push('');
+    parts.push("_If one of these answers your question, feel free to close the issue — otherwise we'll keep digging._");
+    parts.push('');
+  }
+
+  // Invite correction
+  parts.push('### Did I get something wrong?');
+  parts.push('');
+  parts.push(
+    "No worries — a human will still review either way. If the category or " +
+    "topics above are off, just reply with the correct framing (or any extra " +
+    "context, repro steps, or workaround you've tried) and we'll re-route it."
+  );
+  parts.push('');
+
+  // Collapsible team-details block
+  parts.push('---');
+  parts.push('');
+  parts.push('<details><summary>🔎 Triage details (for the team)</summary>');
+  parts.push('');
+  parts.push(`- **Category:** \`${t.category}\` · **Severity:** \`${t.severity}\` · **Confidence:** ${conf} ${t.confidence}`);
+  parts.push(`- **Recommended next step:** \`${stepLabel}\` — ${t.suggested_action}`);
+  if (t.age_signals) {
+    const a = t.age_signals;
+    parts.push(`- **Age:** ${a.age_days}d (${a.age_band}); last activity ${a.last_activity_days}d ago; reporter last spoke ${a.last_reporter_activity_days}d ago${a.stalled_on_reporter ? ' ⚠️ stalled on reporter' : ''}`);
+  }
+  if (topics.length) {
+    parts.push(`- **Detected topics:** ${topics.join(', ')}`);
+  } else {
+    parts.push('- **Detected topics:** _none detected_');
+  }
+  if (labelConflicts.length) {
+    parts.push(`- **⚠️ Existing labels conflict with classification:** ${labelConflicts.map(l => `\`${l}\``).join(', ')}`);
+  }
+  if (dupes.length) {
+    parts.push(`- **Possible duplicates flagged:** ${dupes.map(d => `#${d.number}`).join(', ')}`);
+  }
+  parts.push('- **Rules fired:**');
+  for (const r of t.rules_fired || []) {
+    parts.push(`  - ${r}`);
+  }
+  parts.push('');
+  parts.push('</details>');
+  parts.push('');
+  parts.push(
+    "_Automated triage by the ARM Deployments triage assistant — deterministic " +
+    "rule-based classifier, **no AI/LLM used**. Intended to surface signal for " +
+    "human review, not to take autonomous action._"
+  );
+
+  return parts.join('\n');
+}
+
+function escapeMd(s) {
+  return (s || '').replace(/([\\`*_{}\[\]()#+\-.!|])/g, '\\$1');
+}
+
+export function triageLabels(t) {
+  const labels = ['agent:triaged'];
+  if (t.category) labels.push(`category:${t.category}`);
+  if (t.severity) labels.push(`severity:${t.severity}`);
+  if (t.recommended_next_step) labels.push(`next-step:${t.recommended_next_step}`);
+  for (const topic of t.detected_topics || []) {
+    labels.push(`topic:${topic}`);
+  }
+  return labels;
+}
+
+// Given the triage result + the issue's CURRENT labels, returns category-style
+// labels that conflict with the agent's classification (e.g. `category:bug`
+// already present when the agent classifies as feature-request). Used as a
+// reviewer hint inside the team-details block — the bot does NOT auto-remove.
+export function findExistingLabelConflicts(currentLabels, t) {
+  const names = (currentLabels || [])
+    .map(l => (typeof l === 'string' ? l : l.name))
+    .filter(Boolean);
+  const out = [];
+  for (const name of names) {
+    if (name.startsWith('category:') && name !== `category:${t.category}`) {
+      out.push(name);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
# Add deterministic issue-triage assistant for the ARM Deployments team

This PR adds a small, **no-AI** automated issue-triage bot that helps the team route incoming
issues quickly without burning human triage time on the easy cases. It runs on every newly
opened issue (~1 min latency), and also runs as a nightly batch + on `workflow_dispatch`.

See [`AGENTS.md`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/AGENTS.md) on the branch for the full design + rollback steps.

## What the bot does on each issue

1. **Classifies** it (category / severity / next step / topics / age band) using regex + string matching only.
2. **Posts a single comment** with two audiences:
    - A short reporter-facing block (friendly opener, what it noticed, possible duplicates if any, suggested docs)
    - A `<details>` block with the team's classification, confidence, age signals, and the exact rules that fired
3. **Applies labels** in its own namespace (`agent:triaged`, `category:*`, `severity:*`, `next-step:*`, `topic:*`).

## What it does **not** do

- ❌ No AI, no LLM, no model, no API keys. The full classifier is ~30 KB of Node 20 JS in [`src/`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/).
- ❌ Never auto-closes (not even on duplicate detection — only flags possibilities).
- ❌ Never edits the issue body, never touches closed issues, never opens new issues.
- ❌ No runtime dependencies (`npm install` is unnecessary; uses native `fetch`).
- ❌ No conflict with the existing FabricBot policy in [`.github/policies/resourceManagement.yml`](https://github.com/Azure/deployment-stacks/blob/main/.github/policies/resourceManagement.yml) — the bot uses an `agent:*` / `category:*` / `next-step:*` / `severity:*` / `topic:*` label namespace, FabricBot uses `Needs:*` / `Status:*`.

## Validated on a private mirror

Tested end-to-end on a private mirror (`torreymicrosoft/deployment-stacks-mirror-test`) seeded
with 10 real upstream issues. Confirmed:

- 10/10 classified into the correct category (after fixes for the "Introduce X API" feature-request pattern + scoped by-design close-out)
- All 7 doc URLs return HTTP 200
- Idempotent: re-running the workflow on the same issue posts nothing (marker check)
- Two-audience comment renders correctly on a real GitHub issue
- Phrase-keyed doc selection beats topic-keyed: e.g. `denySettings` issue gets the deny-settings doc, not the generic DS overview

## Layout

| Path | What it is |
| --- | --- |
| [`src/heuristic-triage.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/heuristic-triage.js) | Classifier (category, severity, next-step, topics, age) |
| [`src/docs-pointers.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/docs-pointers.js) | Phrase-first, topic-fallback doc URL selection (cap 3) |
| [`src/duplicate-detection.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/duplicate-detection.js) | Jaccard + shared-topic-label scoring |
| [`src/triage-format.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/triage-format.js) | Two-audience comment renderer |
| [`src/github.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/src/github.js) | GitHub REST helpers + idempotency marker |
| [`scripts/triage-single-issue.js`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/scripts/triage-single-issue.js) | Entry point used by both workflows |
| [`.github/workflows/agent-triage.yml`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/.github/workflows/agent-triage.yml) | On `issues: opened, reopened` + dispatch |
| [`.github/workflows/agent-triage-batch.yml`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/.github/workflows/agent-triage-batch.yml) | Cron `17 3 * * *` + `workflow_dispatch` + `push` to main |
| [`.github/agents/issue-triage-teammate.md`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/.github/agents/issue-triage-teammate.md) | Agent design notes |
| [`AGENTS.md`](https://github.com/Azure/deployment-stacks/blob/agent-issue-triage/AGENTS.md) | Operator guide + rollback steps |

## Auto-backfill on merge

The batch workflow has a `push` trigger on `main` for `src/**`,
`scripts/triage-single-issue.js`, and the batch workflow file itself. So **merging this PR
will automatically run the batch once** and triage every untriaged open issue in the repo —
no manual `workflow_dispatch` needed.

That same trigger also fires on later bot updates, so if we change the classifier and merge,
the change is applied to in-flight issues automatically.

## Age awareness (added in this version)

The opener varies based on how long the issue has been open, and an old-issue nudge is added:

| Age band | Opener |
|---|---|
| `recent` (<30d) / `aging` (30–179d) | "Hi, and thanks for opening this issue." |
| `stale` (180–729d) | "Thanks for your patience on this one." + a "Still relevant?" section |
| `very-old` (≥730d) | "Apologies for the long wait on this one. … recently picked up as an outstanding open issue for the **ARM Deployments team** to review." + a "Still relevant?" section |

## Rollback

```bash
gh workflow disable "Agent — triage on issue open"   --repo Azure/deployment-stacks
gh workflow disable "Agent — nightly batch triage"   --repo Azure/deployment-stacks
```

To fully remove, delete `src/`, `scripts/triage-single-issue.js`, and the two workflow files.
The bot only writes labels + one comment per issue, so nothing else needs cleanup.

## What I'd love a review eye on

- The label namespace choices (open to renaming before any of these labels are created)
- The opener wording — esp. the "very-old" apology copy
- Whether the `push`-triggered auto-backfill is too aggressive (we can drop it and keep just nightly cron + dispatch)
- Any signal patterns I should add to the classifier — happy to extend in a follow-up
